### PR TITLE
Add Halt button on info screen

### DIFF
--- a/src/80_info.js
+++ b/src/80_info.js
@@ -409,6 +409,8 @@ function NewInfoHandler() {
 				status_string += `<span class="green">Self-play! </span>`;
 			} else if (config.behaviour === "auto_analysis") {
 				status_string += `<span class="green">Auto-eval! </span>`;
+			} else if (config.behaviour === "analysis_free") {
+				status_string += `<span id="haltbutton_clicker" class="green">RUNNING (halt?) </span>`;
 			}
 
 			status_string += `<span class="gray">Nodes: ${NString(node.table.nodes)}, N/s: ${NString(node.table.nps)}, Time: ${DurationString(node.table.time)}</span>`;

--- a/src/95_renderer.js
+++ b/src/95_renderer.js
@@ -1548,6 +1548,11 @@ function NewRenderer() {
 		if (EventPathString(event, "gobutton")) {
 			this.set_behaviour("analysis_free");
 			return;
+		}		
+				
+		if (EventPathString(event, "haltbutton")) {
+			this.set_behaviour("halt");
+			return;
 		}
 
 		if (EventPathString(event, "lock_return")) {


### PR DESCRIPTION
Per Issue #117 

Add ability to "Halt" easily from the info section like you can "Go" when halted

I've found this useful when having multiple version of Nibbler open at a time and alternating quickly between them to see when different engines land on a certain line.